### PR TITLE
feat: align recap visuals with figma design

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
             font-family: 'Inter', sans-serif;
             line-height: 1.6;
             color: var(--primary-black);
-            overflow-x: hidden;
+            overflow: hidden;
         }
 
         /* Theme Styles */
@@ -211,7 +211,12 @@
             display: none;
             max-width: 1200px;
             margin: 0 auto;
-            padding: 40px 20px;
+            padding: 20px;
+            height: 100vh;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            overflow: hidden;
         }
 
         .app-header {
@@ -230,8 +235,7 @@
         .controls-section {
             backdrop-filter: blur(20px);
             border-radius: 24px;
-            padding: 40px;
-            margin-bottom: 40px;
+            padding: 20px;
             border: 1px solid;
             transition: all 0.3s ease;
         }
@@ -249,8 +253,8 @@
 
         .form-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-            gap: 30px;
+            grid-template-columns: 1fr;
+            gap: 20px;
         }
 
         .form-group {
@@ -292,14 +296,14 @@
             box-shadow: 0 0 0 3px rgba(204, 69, 3, 0.1);
         }
 
-        .sport-filter {
+        .sport-filter, .period-filter {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
             gap: 12px;
             margin-top: 12px;
         }
 
-        .sport-option {
+        .sport-option, .period-option {
             display: flex;
             align-items: center;
             gap: 10px;
@@ -311,39 +315,27 @@
             border: 1px solid;
         }
 
-        body.theme-dark .sport-option {
+        body.theme-dark .sport-option, body.theme-dark .period-option {
             background: rgba(255, 255, 255, 0.05);
             border-color: rgba(255, 255, 255, 0.1);
         }
 
-        body.theme-light .sport-option {
+        body.theme-light .sport-option, body.theme-light .period-option {
             background: var(--gray-50);
             border-color: var(--gray-200);
         }
 
-        .sport-option:hover {
+        .sport-option:hover, .period-option:hover {
             transform: translateY(-1px);
             border-color: var(--primary-orange);
         }
 
-        .sport-option input[type="checkbox"] {
+        .sport-option input[type="radio"], .period-option input[type="radio"] {
             accent-color: var(--primary-orange);
             width: 18px;
             height: 18px;
         }
 
-        .range-labels {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-top: 10px;
-        }
-
-        #activityCount {
-            font-weight: 700;
-            color: var(--primary-orange);
-            font-size: 1.1rem;
-        }
 
         .generate-btn {
             background: linear-gradient(135deg, var(--primary-orange) 0%, #FF6B35 100%);
@@ -391,7 +383,10 @@
         .canvas-container {
             display: none;
             text-align: center;
-            margin: 40px 0;
+            margin: 20px 0;
+            flex: 1;
+            align-items: center;
+            justify-content: center;
         }
 
         .recap-canvas {
@@ -515,26 +510,6 @@
             font-weight: 500;
         }
 
-        /* Stats Preview */
-        .stats-preview {
-            margin-top: 25px;
-            padding: 20px;
-            border-radius: 16px;
-            font-size: 0.95rem;
-            border: 1px solid;
-            transition: all 0.3s ease;
-        }
-
-        body.theme-dark .stats-preview {
-            background: rgba(255, 255, 255, 0.05);
-            border-color: rgba(255, 255, 255, 0.1);
-        }
-
-        body.theme-light .stats-preview {
-            background: var(--gray-50);
-            border-color: var(--gray-200);
-        }
-
         /* Responsive Design */
         @media (max-width: 768px) {
             .hero {
@@ -637,75 +612,30 @@
         </div>
 
         <div class="controls-section">
-            <div class="form-grid">
-                <div>
-                    <div class="form-group">
-                        <label for="monthSelect">Période</label>
-                        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 15px;">
-                            <select id="monthSelect">
-                                <option value="1">Janvier</option>
-                                <option value="2">Février</option>
-                                <option value="3">Mars</option>
-                                <option value="4">Avril</option>
-                                <option value="5">Mai</option>
-                                <option value="6">Juin</option>
-                                <option value="7" selected>Juillet</option>
-                                <option value="8">Août</option>
-                                <option value="9">Septembre</option>
-                                <option value="10">Octobre</option>
-                                <option value="11">Novembre</option>
-                                <option value="12">Décembre</option>
-                            </select>
-                            <select id="yearSelect">
-                                <option value="2023">2023</option>
-                                <option value="2024">2024</option>
-                                <option value="2025" selected>2025</option>
-                            </select>
-                        </div>
+            <div class="form-group">
+                <label>Période</label>
+                <div class="period-filter">
+                    <div class="period-option">
+                        <input type="radio" id="period-month" name="period-type" value="month" checked>
+                        <label for="period-month">📅 Mois en cours</label>
                     </div>
-
-                    <div class="form-group">
-                        <label for="maxActivities">Nombre d'activités à afficher</label>
-                        <input type="range" id="maxActivities" min="0" max="30" value="16" 
-                               oninput="updateActivityCount(this.value)">
-                        <div class="range-labels">
-                            <span>0</span>
-                            <span id="activityCount">16 activités</span>
-                            <span>30</span>
-                        </div>
+                    <div class="period-option">
+                        <input type="radio" id="period-week" name="period-type" value="week">
+                        <label for="period-week">🗓️ Semaine en cours</label>
                     </div>
                 </div>
+            </div>
 
-                <div>
-                    <div class="form-group">
-                        <label>Sports à inclure</label>
-                        <div class="sport-filter">
-                            <div class="sport-option">
-                                <input type="checkbox" id="all-sports" checked onchange="toggleAllSports()">
-                                <label for="all-sports">Tous</label>
-                            </div>
-                            <div class="sport-option">
-                                <input type="checkbox" id="sport-ride" class="sport-checkbox" value="Ride">
-                                <label for="sport-ride">🚴 Vélo</label>
-                            </div>
-                            <div class="sport-option">
-                                <input type="checkbox" id="sport-run" class="sport-checkbox" value="Run">
-                                <label for="sport-run">🏃 Course</label>
-                            </div>
-                            <div class="sport-option">
-                                <input type="checkbox" id="sport-swim" class="sport-checkbox" value="Swim">
-                                <label for="sport-swim">🏊 Natation</label>
-                            </div>
-                            <div class="sport-option">
-                                <input type="checkbox" id="sport-hike" class="sport-checkbox" value="Hike">
-                                <label for="sport-hike">🥾 Randonnée</label>
-                            </div>
-                        </div>
+            <div class="form-group">
+                <label>Sport à afficher</label>
+                <div class="sport-filter">
+                    <div class="sport-option">
+                        <input type="radio" id="sport-ride" name="sport-type" value="Ride" checked>
+                        <label for="sport-ride">🚴 Vélo</label>
                     </div>
-
-                    <div class="stats-preview" id="statsPreview" style="display: none;">
-                        <strong>Aperçu des données :</strong>
-                        <div id="statsContent"></div>
+                    <div class="sport-option">
+                        <input type="radio" id="sport-swim" name="sport-type" value="Swim">
+                        <label for="sport-swim">🏊 Natation</label>
                     </div>
                 </div>
             </div>
@@ -768,18 +698,35 @@
             }
         });
 
-        function updateActivityCount(value) {
-            const text = value == 0 ? 'Aucune activité' : value == 1 ? '1 activité' : `${value} activités`;
-            document.getElementById('activityCount').textContent = text;
+        function getCurrentMonthName() {
+            const monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+            return monthNames[new Date().getMonth()];
         }
 
-        function toggleAllSports() {
-            const allSportsCheckbox = document.getElementById('all-sports');
-            const sportCheckboxes = document.querySelectorAll('.sport-checkbox');
-            
-            sportCheckboxes.forEach(checkbox => {
-                checkbox.checked = allSportsCheckbox.checked;
-            });
+        function getCurrentMonthRange() {
+            const now = new Date();
+            return {
+                start: new Date(now.getFullYear(), now.getMonth(), 1),
+                end: new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999)
+            };
+        }
+
+        function getCurrentWeekRange() {
+            const now = new Date();
+            const day = now.getDay();
+            const diff = now.getDate() - day + (day === 0 ? -6 : 1);
+            const start = new Date(now.setDate(diff));
+            start.setHours(0,0,0,0);
+            const end = new Date(start);
+            end.setDate(start.getDate() + 6);
+            end.setHours(23,59,59,999);
+            return { start, end };
+        }
+
+        function getCurrentWeekLabel() {
+            const { start, end } = getCurrentWeekRange();
+            const options = { day: 'numeric', month: 'long' };
+            return `${start.toLocaleDateString('fr-FR', options)} - ${end.toLocaleDateString('fr-FR', options)}`;
         }
 
         function calculateGridDimensions(activityCount) {
@@ -822,7 +769,8 @@
                     document.getElementById('appContainer').style.display = 'block';
                     
                     window.history.replaceState({}, document.title, window.location.pathname);
-                    loadActivityPreview();
+                    const range = getCurrentMonthRange();
+                    await fetchActivities(range.start, range.end);
                 } else {
                     showError('Erreur lors de l\'authentification Strava');
                 }
@@ -831,54 +779,10 @@
             }
         }
 
-        async function loadActivityPreview() {
-            try {
-                const month = parseInt(document.getElementById('monthSelect').value);
-                const year = parseInt(document.getElementById('yearSelect').value);
-                await fetchActivities(month, year);
-                updateStatsPreview();
-            } catch (error) {
-                console.error('Erreur lors du chargement de l\'aperçu:', error);
-            }
-        }
-
-        function updateStatsPreview() {
-            if (activities.length === 0) return;
-            
-            const filteredActivities = getFilteredActivities();
-            const totalDistance = filteredActivities.reduce((sum, act) => sum + (act.distance || 0), 0);
-            const totalTime = filteredActivities.reduce((sum, act) => sum + (act.moving_time || 0), 0);
-            
-            const statsContent = `
-                ${filteredActivities.length} activités • 
-                ${(totalDistance / 1000).toFixed(1)}km • 
-                ${Math.floor(totalTime / 3600)}h${Math.floor((totalTime % 3600) / 60).toString().padStart(2, '0')}
-            `;
-            
-            document.getElementById('statsContent').textContent = statsContent;
-            document.getElementById('statsPreview').style.display = 'block';
-        }
 
         function getFilteredActivities() {
-            const allSportsChecked = document.getElementById('all-sports').checked;
-            
-            if (allSportsChecked) {
-                return activities;
-            }
-            
-            const selectedSports = [];
-            document.querySelectorAll('.sport-checkbox:checked').forEach(checkbox => {
-                selectedSports.push(checkbox.value);
-            });
-            
-            if (selectedSports.length === 0) {
-                return activities;
-            }
-            
-            return activities.filter(activity => {
-                return selectedSports.includes(activity.sport_type) || 
-                       (selectedSports.includes('Other') && !['Ride', 'Run', 'Swim', 'Hike'].includes(activity.sport_type));
-            });
+            const selectedSport = document.querySelector('input[name="sport-type"]:checked').value;
+            return activities.filter(activity => activity.sport_type === selectedSport);
         }
 
         async function generateRecap() {
@@ -887,16 +791,23 @@
                 return;
             }
 
-            const month = parseInt(document.getElementById('monthSelect').value);
-            const year = parseInt(document.getElementById('yearSelect').value);
+            const period = document.querySelector('input[name="period-type"]:checked').value;
+            let range, label;
+            if (period === 'week') {
+                range = getCurrentWeekRange();
+                label = getCurrentWeekLabel();
+            } else {
+                range = getCurrentMonthRange();
+                label = getCurrentMonthName();
+            }
 
             document.getElementById('loading').style.display = 'block';
             document.getElementById('generateBtn').disabled = true;
             document.getElementById('error').style.display = 'none';
 
             try {
-                await fetchActivities(month, year);
-                drawRecap(month, year);
+                await fetchActivities(range.start, range.end);
+                drawRecap(period, label);
             } catch (error) {
                 showError('Erreur lors de la génération: ' + error.message);
             } finally {
@@ -905,12 +816,9 @@
             }
         }
 
-        async function fetchActivities(month, year) {
-            const startOfMonth = new Date(year, month - 1, 1);
-            const endOfMonth = new Date(year, month, 0, 23, 59, 59);
-            
-            const after = Math.floor(startOfMonth.getTime() / 1000);
-            const before = Math.floor(endOfMonth.getTime() / 1000);
+        async function fetchActivities(startDate, endDate) {
+            const after = Math.floor(startDate.getTime() / 1000);
+            const before = Math.floor(endDate.getTime() / 1000);
 
             const response = await fetch(
                 `https://www.strava.com/api/v3/athlete/activities?after=${after}&before=${before}&per_page=200`,
@@ -928,118 +836,156 @@
             activities = await response.json();
         }
 
-        function drawRecap(month, year) {
+        function drawRecap(period, label) {
             const canvas = document.getElementById('recapCanvas');
             const ctx = canvas.getContext('2d');
 
             const filteredActivities = getFilteredActivities();
-            const maxActivities = parseInt(document.getElementById('maxActivities').value);
-            const activitiesToShow = filteredActivities.slice(0, maxActivities);
-            const { cols, rows } = calculateGridDimensions(activitiesToShow.length);
+            const activitiesToShow = filteredActivities;
 
-            // Couleurs selon le thème
-            const isLightTheme = currentTheme === 'light';
-            const bgColor = isLightTheme ? '#FFFFFF' : '#0a0a0a';
-            const textColor = isLightTheme ? '#0F0F10' : '#FFFFFF';
-            const traceColor = '#CC4503';
-
-            // Fond
-            ctx.fillStyle = bgColor;
+            // Structure CSS Figma - fond noir pur
+            ctx.fillStyle = '#000000';
             ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-            // Titre principal
-            ctx.fillStyle = textColor;
-            ctx.font = '300 48px Inter';
+            const topPadding = 150;
+            let currentY = topPadding;
+
+            // Section 1: Titre principal
+            ctx.fillStyle = '#FFFFFF';
+            ctx.font = '400 56px Inter';
             ctx.textAlign = 'center';
-            ctx.fillText('Récap du mois', canvas.width / 2, 150);
+            const mainTitle = period === 'week' ? 'Recap of the week' : 'Recap of the month';
+            ctx.fillText(mainTitle, canvas.width / 2, currentY + 56);
 
-            // Mois
-            const monthNames = ['', 'Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin', 
-                             'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre'];
-            ctx.font = '700 72px Inter';
-            ctx.fillText(monthNames[month], canvas.width / 2, 230);
+            currentY += 56 + 40;
 
-            if (activitiesToShow.length === 0) {
-                ctx.font = '400 32px Inter';
-                ctx.fillStyle = '#888888';
-                ctx.fillText('Aucune activité trouvée', canvas.width / 2, 600);
-                
-                drawStats(ctx, filteredActivities, canvas.width / 2, 800, textColor);
-            } else {
-                // Zone pour les tracés
-                const gridStartY = 320;
-                const maxGridWidth = 900;
-                const maxGridHeight = 900;
-                
-                const cellSize = Math.min(maxGridWidth / cols, maxGridHeight / rows, 180);
-                const gridWidth = cols * cellSize;
-                const gridHeight = rows * cellSize;
-                const gridStartX = (canvas.width - gridWidth) / 2;
+            // Section 2: Sous-titre
+            ctx.font = 'italic 600 48px Inter';
+            const subtitle = period === 'week' ? label : `Month [${label}]`;
+            ctx.fillText(subtitle, canvas.width / 2, currentY + 48);
 
-                // Dessiner les tracés
-                activitiesToShow.forEach((activity, index) => {
-                    const row = Math.floor(index / cols);
-                    const col = index % cols;
-                    const x = gridStartX + col * cellSize;
-                    const y = gridStartY + row * cellSize;
-                    
-                    drawActivityTrace(ctx, activity, x, y, cellSize, traceColor);
-                });
+            currentY += 48 + 100;
 
-                // Statistiques
-                const statsY = gridStartY + gridHeight + 80;
-                drawStats(ctx, filteredActivities, canvas.width / 2, statsY, textColor);
+            // Section 3: Grille des tracés - Layout Figma centré
+            const { cols, rows } = calculateGridDimensions(activitiesToShow.length);
+            const gridWidth = 800;
+            const cellWidth = gridWidth / cols;
+            const cellHeight = gridWidth / cols;
+            const gridHeight = cellHeight * rows;
+            const gridStartX = (canvas.width - gridWidth) / 2;
+            const gridStartY = currentY;
+
+            const totalCells = cols * rows;
+            for (let i = 0; i < totalCells; i++) {
+                const row = Math.floor(i / cols);
+                const col = i % cols;
+                const x = gridStartX + col * cellWidth;
+                const y = gridStartY + row * cellHeight;
+
+                if (i < activitiesToShow.length) {
+                    drawFigmaTrace(ctx, activitiesToShow[i], x, y, cellWidth, cellHeight);
+                }
             }
+
+            currentY = gridStartY + gridHeight + 100;
+
+            // Section 4: Statistiques
+            drawCSSStats(ctx, filteredActivities, canvas.width / 2, currentY);
+
+            currentY += 120 + 50;
+
+            // Section 5: Logo Strava
+            drawCSSStravaLogo(ctx, canvas.width / 2, currentY);
 
             // Générer l'URL de l'image
             generatedImageUrl = canvas.toDataURL('image/png');
 
             // Afficher le canvas et les boutons
-            document.getElementById('canvasContainer').style.display = 'block';
+            document.getElementById('canvasContainer').style.display = 'flex';
             document.getElementById('actionButtons').style.display = 'flex';
         }
 
-        function drawStats(ctx, activities, centerX, startY, textColor) {
+        function drawCSSStats(ctx, activities, centerX, startY) {
             const totalDistance = activities.reduce((sum, act) => sum + (act.distance || 0), 0);
             const totalTime = activities.reduce((sum, act) => sum + (act.moving_time || 0), 0);
             const totalElevation = activities.reduce((sum, act) => sum + (act.total_elevation_gain || 0), 0);
 
-            ctx.font = '600 42px Inter';
-            ctx.fillStyle = textColor;
-            ctx.textAlign = 'left';
-            
-            const leftX = centerX - 200;
-            const rightX = centerX + 50;
-            
-            ctx.fillText(`${activities.length} activités`, leftX, startY);
-            ctx.fillText(`${(totalDistance / 1000).toFixed(1)}km`, rightX, startY);
-            
-            const hours = Math.floor(totalTime / 3600);
-            ctx.fillText(`${hours}h`, leftX, startY + 80);
-            ctx.fillText(`${Math.round(totalElevation)}m dénivelé`, rightX, startY + 80);
-
-            // Logo Strava
-            ctx.font = '400 32px Inter';
+            ctx.font = 'italic 700 42px Inter';
+            ctx.fillStyle = '#FFFFFF';
             ctx.textAlign = 'center';
-            ctx.fillStyle = '#888888';
-            ctx.fillText('@strava', centerX, startY + 200);
+
+            const statsWidth = 600;
+            const statsStartX = centerX - statsWidth / 2;
+
+            ctx.textAlign = 'left';
+            ctx.fillText(`${activities.length} activities`, statsStartX, startY);
+            ctx.textAlign = 'right';
+            ctx.fillText(`${Math.round(totalDistance / 1000)} km`, statsStartX + statsWidth, startY);
+
+            ctx.textAlign = 'left';
+            const hours = Math.floor(totalTime / 3600);
+            ctx.fillText(`${hours} hours`, statsStartX, startY + 60);
+            ctx.textAlign = 'right';
+            ctx.fillText(`${Math.round(totalElevation)} elevation`, statsStartX + statsWidth, startY + 60);
         }
 
-        function drawActivityTrace(ctx, activity, x, y, size, color) {
-            if (!activity.map || !activity.map.summary_polyline) {
-                drawGenericTrace(ctx, x, y, size, color);
-                return;
+        function drawCSSStravaLogo(ctx, centerX, y) {
+            const logoSize = 40;
+            const logoX = centerX - logoSize / 2;
+
+            ctx.fillStyle = '#FFFFFF';
+
+            ctx.beginPath();
+            ctx.moveTo(logoX, y + logoSize);
+            ctx.lineTo(logoX + logoSize * 0.3, y);
+            ctx.lineTo(logoX + logoSize * 0.6, y + logoSize * 0.4);
+            ctx.lineTo(logoX + logoSize * 0.4, y + logoSize * 0.4);
+            ctx.lineTo(logoX + logoSize, y + logoSize);
+            ctx.closePath();
+            ctx.fill();
+        }
+
+        function drawFigmaTrace(ctx, activity, x, y, width, height) {
+            const centerX = x + width / 2;
+            const centerY = y + height / 2;
+            const traceWidth = width * 0.7;
+            const traceHeight = height * 0.4;
+
+            ctx.strokeStyle = '#CC4503';
+            ctx.lineWidth = 4;
+            ctx.lineCap = 'round';
+            ctx.lineJoin = 'round';
+
+            if (activity.map && activity.map.summary_polyline) {
+                const points = decodePolyline(activity.map.summary_polyline);
+                if (points.length >= 2) {
+                    drawRealTrace(ctx, points, x, y, width, height);
+                    return;
+                }
             }
 
-            const points = decodePolyline(activity.map.summary_polyline);
-            if (points.length < 2) {
-                drawGenericTrace(ctx, x, y, size, color);
-                return;
-            }
+            ctx.beginPath();
+            const startX = centerX - traceWidth / 2;
+            const endX = centerX + traceWidth / 2;
+            const startY = centerY + (Math.random() - 0.5) * traceHeight;
+            const endY = centerY + (Math.random() - 0.5) * traceHeight;
+
+            const cp1X = startX + traceWidth * 0.3;
+            const cp1Y = startY + (Math.random() - 0.5) * traceHeight;
+            const cp2X = startX + traceWidth * 0.7;
+            const cp2Y = endY + (Math.random() - 0.5) * traceHeight;
+
+            ctx.moveTo(startX, startY);
+            ctx.bezierCurveTo(cp1X, cp1Y, cp2X, cp2Y, endX, endY);
+            ctx.stroke();
+        }
+
+        function drawRealTrace(ctx, points, x, y, width, height) {
+            if (points.length < 2) return;
 
             let minLat = points[0][0], maxLat = points[0][0];
             let minLng = points[0][1], maxLng = points[0][1];
-            
+
             points.forEach(point => {
                 minLat = Math.min(minLat, point[0]);
                 maxLat = Math.max(maxLat, point[0]);
@@ -1047,12 +993,12 @@
                 maxLng = Math.max(maxLng, point[1]);
             });
 
-            const padding = size * 0.1;
-            const drawWidth = size - 2 * padding;
-            const drawHeight = size - 2 * padding;
+            const padding = Math.min(width, height) * 0.15;
+            const drawWidth = width - 2 * padding;
+            const drawHeight = height - 2 * padding;
 
-            ctx.strokeStyle = color;
-            ctx.lineWidth = 3;
+            ctx.strokeStyle = '#CC4503';
+            ctx.lineWidth = 4;
             ctx.lineCap = 'round';
             ctx.lineJoin = 'round';
             ctx.beginPath();
@@ -1060,7 +1006,7 @@
             points.forEach((point, index) => {
                 const px = x + padding + ((point[1] - minLng) / (maxLng - minLng)) * drawWidth;
                 const py = y + padding + ((maxLat - point[0]) / (maxLat - minLat)) * drawHeight;
-                
+
                 if (index === 0) {
                     ctx.moveTo(px, py);
                 } else {
@@ -1071,32 +1017,8 @@
             ctx.stroke();
         }
 
-        function drawGenericTrace(ctx, x, y, size, color) {
-            const padding = size * 0.2;
-            const points = [];
-            
-            for (let i = 0; i < 8; i++) {
-                points.push([
-                    x + padding + Math.random() * (size - 2 * padding),
-                    y + padding + Math.random() * (size - 2 * padding)
-                ]);
-            }
-
-            ctx.strokeStyle = color;
-            ctx.lineWidth = 3;
-            ctx.lineCap = 'round';
-            ctx.lineJoin = 'round';
-            ctx.beginPath();
-
-            points.forEach((point, index) => {
-                if (index === 0) {
-                    ctx.moveTo(point[0], point[1]);
-                } else {
-                    ctx.lineTo(point[0], point[1]);
-                }
-            });
-
-            ctx.stroke();
+        function drawEmptyTrace(ctx, x, y, width, height) {
+            return;
         }
 
         function decodePolyline(str) {


### PR DESCRIPTION
## Summary
- Support current month or week selection without manual date inputs
- Automatically render all activities and remove activity count slider
- Use full-height mobile layout to keep recap tools on a single screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952a8e9a40832eab7eb64539807b60