### PR TITLE
fix: handle zero-range activity traces

### DIFF
--- a/index.html
+++ b/index.html
@@ -1039,13 +1039,17 @@
 
             let minLat = points[0][0], maxLat = points[0][0];
             let minLng = points[0][1], maxLng = points[0][1];
-            
+
             points.forEach(point => {
                 minLat = Math.min(minLat, point[0]);
                 maxLat = Math.max(maxLat, point[0]);
                 minLng = Math.min(minLng, point[1]);
                 maxLng = Math.max(maxLng, point[1]);
             });
+
+            // Avoid division by zero when the activity has no spread in latitude or longitude
+            const latRange = Math.max(maxLat - minLat, 1e-6);
+            const lngRange = Math.max(maxLng - minLng, 1e-6);
 
             const padding = size * 0.1;
             const drawWidth = size - 2 * padding;
@@ -1058,9 +1062,9 @@
             ctx.beginPath();
 
             points.forEach((point, index) => {
-                const px = x + padding + ((point[1] - minLng) / (maxLng - minLng)) * drawWidth;
-                const py = y + padding + ((maxLat - point[0]) / (maxLat - minLat)) * drawHeight;
-                
+                const px = x + padding + ((point[1] - minLng) / lngRange) * drawWidth;
+                const py = y + padding + ((maxLat - point[0]) / latRange) * drawHeight;
+
                 if (index === 0) {
                     ctx.moveTo(px, py);
                 } else {

--- a/index.html
+++ b/index.html
@@ -1091,7 +1091,6 @@
             ctx.lineCap = 'round';
             ctx.lineJoin = 'round';
             ctx.beginPath();
-
             points.forEach((point, index) => {
                 if (index === 0) {
                     ctx.moveTo(point[0], point[1]);
@@ -1099,7 +1098,6 @@
                     ctx.lineTo(point[0], point[1]);
                 }
             });
-
             ctx.stroke();
         }
 
@@ -1112,7 +1110,6 @@
                 byte = null;
                 shift = 0;
                 result = 0;
-
                 do {
                     byte = str.charCodeAt(index++) - 63;
                     result |= (byte & 0x1f) << shift;
@@ -1121,10 +1118,8 @@
 
                 const deltaLat = ((result & 1) ? ~(result >> 1) : (result >> 1));
                 lat += deltaLat;
-
                 shift = 0;
                 result = 0;
-
                 do {
                     byte = str.charCodeAt(index++) - 63;
                     result |= (byte & 0x1f) << shift;


### PR DESCRIPTION
## Summary
- prevent division by zero when drawing activity traces

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952a4ff074832e915a176ab7c8a9ea